### PR TITLE
fixed CONTXY2DISC  when x is an  expression

### DIFF
--- a/include/voronoi_planner/voronoi_planner_ros.h
+++ b/include/voronoi_planner/voronoi_planner_ros.h
@@ -43,8 +43,8 @@
 #include "voronoi_planner/voronoi_planner.h"
 
 #define CONTXY2DISC(X, CELLSIZE)               \
-  ((X >= 0) ? (static_cast<int>(X / CELLSIZE)) \
-            : (static_cast<int>(X / CELLSIZE) - 1))
+  (((X) >= 0) ? (static_cast<int>((X) / CELLSIZE)) \
+            : (static_cast<int>((X) / CELLSIZE) - 1))
 #define DISCXY2CONT(X, CELLSIZE) ((X) * (CELLSIZE) + (CELLSIZE) / 2.0)
 
 namespace voronoi_planner {


### PR DESCRIPTION
goal_x = CONTXY2DISC(goal.pose.position.x - origin_x, resolution);   may has an error .

https://github.com/nkuwenjian/voronoi_planner/blob/melodic-devel/src/voronoi_planner_ros.cpp#L143-L146